### PR TITLE
Matrix.cast should copy the data

### DIFF
--- a/src/dependenpy/structures.py
+++ b/src/dependenpy/structures.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -94,8 +95,8 @@ class Matrix(PrintMixin):
             A new matrix.
         """
         matrix = Matrix()
-        matrix.keys = keys
-        matrix.data = data
+        matrix.keys = copy.deepcopy(keys)
+        matrix.data = copy.deepcopy(data)
         return matrix
 
     @property


### PR DESCRIPTION
If just assigning the values, then the data is shared and changing it affects everyone that has a reference to it.