### PR TITLE
Add sequencing of DSM matrix (WIP)

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+    "exclude": [
+        "__pypackages__"
+    ]
+}

--- a/src/dependenpy/algorithms.py
+++ b/src/dependenpy/algorithms.py
@@ -1,0 +1,328 @@
+"""dependenpy alogorithms module.
+
+https://dsmweb.org/sequencing-a-dsm/
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any, List, Tuple
+
+from dependenpy.structures import Matrix
+
+if TYPE_CHECKING:
+    from dependenpy.dsm import DSM, Module, Package
+
+
+class DsmMatrix(Matrix):
+    """_summary_."""
+
+    def __init__(self, *nodes: DSM | Package | Module, depth: int = 0):
+        """_summary_.
+
+        Args:
+            *nodes: The nodes on which to build the matrix.
+            depth: The depth of the matrix. This depth is always
+                absolute, meaning that building a matrix with a sub-package
+                "A.B.C" and a depth of 1 will return a matrix of size 1,
+                containing A only. To see the matrix for the sub-modules and
+                sub-packages in C, you will have to give depth=4.
+        """
+        super().__init__(*nodes, depth=depth)
+        self.front = 0
+        self.back = len(self.keys)
+        self.info = {item: {} for item in self.keys}  # assumes items are strings...
+
+    @property
+    def rank(self):
+        return len(self.keys)
+
+    @staticmethod
+    def create(matrix: Matrix) -> DsmMatrix:  # noqa: WPS602
+        """_summary_.
+
+        Args:
+            matrix (Matrix): _description_
+
+        Returns:
+            DsmMatrix: _description_
+        """
+        result = DsmMatrix()
+        result.keys = copy.deepcopy(matrix.keys)
+        result.key_info = copy.deepcopy(matrix.key_info)
+        result.data = copy.deepcopy(matrix.data)
+        result.front = 0
+        result.back = result.rank
+        return result
+
+    def copy(self) -> DsmMatrix:
+        """_summary_.
+
+        Returns:
+            DsmMatrix: The return value.
+        """
+        result = DsmMatrix()
+        result.keys = copy.deepcopy(self.keys)
+        result.key_info = copy.deepcopy(self.key_info)
+        result.data = copy.deepcopy(self.data)
+        result.front = self.front
+        result.back = self.back
+        return result
+
+    def index_of(self, name: Any) -> int:
+        """_summary_.
+
+        Args:
+            name (Any): _description_
+
+        Returns:
+            int: _description_
+        """
+        return self.keys.index(name)
+
+    def get_inputs(self, index: int) -> list:
+        return self.data[index]
+
+    def get_outputs(self, index: int) -> list:
+        return [item[index] for item in self.data]
+
+    def has_inputs(self, index: int) -> bool:
+        return any(self.get_inputs(index))
+
+    def has_outputs(self, index: int) -> bool:
+        return any(self.get_outputs(index))
+
+    def sequence(self) -> DsmMatrix:
+        """Reorder elements in matrix so that they are as close as possible to diagonal.
+
+        Identify loops and clusters of interdependent modules.
+
+        1. For each element, if it does not depend on any other (empty column), move to beginning and ignore hereafter.
+        2. For each element, if nobody depends on it (empty row), move to end and ignore hereafter.
+        3. For the rest of the elements, find loops by decomposition or partition
+        4. Collapse each loop into onecompounded element, and go to step 1.
+
+        Args:
+            matrix (DsmMatrix): _description_
+        """
+        result1 = self
+        for item in range(result1.front, result1.back):
+            print("---", item, result1.front, result1.back)
+            if not self.has_inputs(item):
+                # print(">")
+                result1 = result1.element_to_back(item)
+            elif not self.has_outputs(item):
+                # print("<")
+                result1 = result1.element_to_front(item)
+            else:
+                # print("=")
+                pass
+        return result1
+
+    def decompose(self):
+        """_summary_.
+
+        Args:
+            matrix (DsmMatrix): _description_
+        """
+
+    def partition(self) -> List[Tuple[str, int]]:
+        """Builds a hierarchy of elements.
+
+        Inside a level the elements are either not connected to each other, or are part of the same circuit at that level.
+
+        The top level is composed of all elements that require no input or are independent from all other elements.
+        Removing these elements from the matrix, leaves a new matrix whose top level is the secont level of the original one.
+        In this manner, all levels can be identified.
+
+        For each element,list the set of their inputs (including the element itself), the set of the outputs
+        (including the element itself) and the intersection of these sets.
+        If the input set equals the intersection set, it is a top element.
+        After identifying all top elements, remove them and proceed recursively.
+
+        The result is an list of tuples (element, level), where the top level is 1.
+
+        Args:
+            matrix (DsmMatrix): _description_
+
+        Returns:
+            List[Tuple[str, int]]: _description_
+        """
+        return []
+
+    def _switch_rows(self, source: int, target: int) -> DsmMatrix:
+        """Returns a matrix with the given rows switched.
+
+        Args:
+            source: (int): _description_
+            target (int): _description_
+
+        Returns:
+            DsmMatrix: _description_
+        """
+        result = self.copy()
+        ii, jj = result.data[target], result.data[source]
+        result.data[source] = ii
+        result.data[target] = jj
+        return result
+
+    def _switch_columns(self, source: int, target: int) -> DsmMatrix:
+        """Returns a matrix with the given columns switched.
+
+        Args:
+            source: (int): _description_
+            target (int): _description_
+
+        Returns:
+            DsmMatrix: _description_
+        """
+        result = self.copy()
+        size = result.rank
+        for ix in range(0, size):
+            ii, jj = result.data[ix][target], result.data[ix][source]
+            result.data[ix][source] = ii
+            result.data[ix][target] = jj
+        return result
+
+    def switch_elements(self, source: int, target: int) -> DsmMatrix:
+        """Returns a matrix with the given rows and columns switched, as well as the keys.
+
+        Args:
+            source: (int): _description_
+            target (int): _description_
+
+        Returns:
+            DsmMatrix: _description_
+        """
+        result = self._switch_rows(source, target)
+        result = result._switch_columns(source, target)
+        ii, jj = result.keys[target], result.keys[source]
+        result.keys[source] = ii
+        result.keys[target] = jj
+        return result
+
+    def element_to_front(self, index: int) -> DsmMatrix:
+        """Switch index with matrix.front, and increment matrix.front.
+
+        Args:
+            matrix (DsmMatrix): _description_
+            index (int): _description_
+
+        Returns:
+            DsmMatrix: _description_
+        """
+        if index <= self.front:
+            return self
+        result = self.switch_elements(index, self.front)
+        result.front += 1
+        return result
+
+    def element_to_back(self, index: int) -> DsmMatrix:
+        """Switch index with matrix.back, and decrement matrix.back.
+
+        Args:
+            matrix (DsmMatrix): _description_
+            index (int): _description_
+
+        Returns:
+            DsmMatrix: _description_
+        """
+        if index >= self.back:
+            return self
+        result = self.switch_elements(index, self.back - 1)
+        result.back -= 1
+        return result
+
+    def reachability(self):
+        """Return the reachability matrix.
+
+        In this matrix, an 1 in cell (i,j) means there is a path going from i to j.
+        """
+        return self._plus_unity()._as_boolean()._power(self.rank)._as_boolean()
+
+    def _power(self, power: int):
+        result = self.copy()
+        if power < 2:
+            return result
+        for _ in range(power - 1):
+            result.data = _multiply(result.data, self.data)
+        return result
+
+    def _as_boolean(self):
+        result = self.copy()
+        for ii in range(result.rank):
+            for jj in range(result.rank):
+                if result.data[ii][jj]:
+                    result.data[ii][jj] = 1
+        return result
+
+    def _plus_unity(self):
+        result = self.copy()
+        for ii in range(result.rank):
+            result.data[ii][ii] += 1
+        return result
+
+    def is_top_level_element(self, index: int) -> bool:
+        reach = int("".join(str(x) for x in self.data[index]), 2)
+        ante = int("".join(str(x) for x in [r[index] for r in self.data]), 2)
+        return reach & ante == ante
+
+    def remove_element(self, index: int) -> DsmMatrix:
+        result = self.copy()
+        del result.keys[index]
+        del result.data[index]
+        for cc in result.data:
+            del cc[index]
+        return result
+
+    def reorder(self, new_keys: List[str]):
+        swaps = _find_swaps(self.keys, new_keys)
+        result = self.copy()
+        for ii, jj in swaps:
+            result = result.switch_elements(ii, jj)
+        return result
+
+    def levelize(self):
+        levels = self.get_levels()
+        for ix, ks in enumerate(levels):
+            for k in ks:
+                self.key_info[k].level=ix
+        return self.reorder(_flatten(levels))
+
+    def get_levels(self):
+        m = self.reachability()
+        levels = []
+        while m.rank > 1:
+            tops = []
+            for ii in range(m.rank):
+                if m.is_top_level_element(ii):
+                    tops.append(ii)
+            levels.append([m.keys[x] for x in tops])
+            for index, ii in enumerate(tops):
+                m = m.remove_element(ii - index)
+        if m.keys:
+            levels.append(m.keys)
+        return levels
+
+
+def _multiply(matrix1, matrix2):
+    """Multiply two matrices"""
+    return [[sum(a * b for a, b in zip(row, col)) for col in zip(*matrix2)] for row in matrix1]
+
+
+def _find_swaps(source, target):
+    source = copy.copy(source)
+    target = copy.copy(target)
+    result = []
+    for index in range(len(source)):
+        if source[index] == target[index]:
+            continue
+        dest = source.index(target[index])
+        result.append((index, dest))
+        source[index], source[dest] = source[dest], source[index]
+
+    return result
+
+
+def _flatten(alist):
+    return [x for xs in alist for x in xs]

--- a/src/dependenpy/cli.py
+++ b/src/dependenpy/cli.py
@@ -20,7 +20,7 @@ from typing import List, Optional
 
 from colorama import init
 
-from dependenpy import __version__
+from dependenpy import __version__, algorithms
 from dependenpy.dsm import DSM
 from dependenpy.helpers import CSV, FORMAT, JSON, guess_depth
 
@@ -179,6 +179,9 @@ def _run(opts, dsm):
             dsm.print(format=opts.format, output=output, indent=indent)
         elif opts.matrix:
             dsm.print_matrix(format=opts.format, output=output, depth=depth, indent=indent, zero=opts.zero)
+            algorithms.DsmMatrix.create(dsm.as_matrix()).levelize().print(
+                format=opts.format, output=output, depth=depth, indent=indent, zero=opts.zero
+            )
         elif opts.treemap:
             dsm.print_treemap(format=opts.format, output=output)
         elif opts.graph:

--- a/src/dependenpy/structures.py
+++ b/src/dependenpy/structures.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -94,8 +95,8 @@ class Matrix(PrintMixin):
             A new matrix.
         """
         matrix = Matrix()
-        matrix.keys = keys
-        matrix.data = data
+        matrix.keys = copy.deepcopy(keys)
+        matrix.data = copy.deepcopy(data)
         return matrix
 
     @property

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,0 +1,192 @@
+"""Tests for algorithms."""
+
+import pytest
+
+from dependenpy import algorithms, structures
+
+
+@pytest.fixture()
+def full_matrix() -> algorithms.DsmMatrix:
+    """A default matrix to test with.
+
+    Returns:
+        algorithms.DsmMatrix: _description_
+    """
+    matrix = structures.Matrix.cast(
+        ["a", "b", "c", "d"],
+        [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16],
+        ],
+    )
+    return algorithms.DsmMatrix.create(matrix)
+
+
+@pytest.fixture()
+def sparse_matrix() -> algorithms.DsmMatrix:
+    """A default sparse matrix to test with.
+
+    Returns:
+        algorithms.DsmMatrix: _description_
+    """
+    matrix = structures.Matrix.cast(
+        ["a", "b", "c", "d"],
+        [
+            [1, 2, 0, 4],
+            [0, 0, 0, 0],
+            [9, 10, 0, 12],
+            [13, 14, 0, 16],
+        ],
+    )
+    return algorithms.DsmMatrix.create(matrix)
+
+
+@pytest.fixture()
+def complex_matrix() -> algorithms.DsmMatrix:
+    """A default sparse matrix to test with.
+
+    Returns:
+        algorithms.DsmMatrix: _description_
+    """
+    matrix = structures.Matrix.cast(
+        ["a", "b", "c", "d", "e", "f", "g"],
+        [
+            [0, 0, 2, 0, 0, 0, 0],
+            [0, 0, 1, 3, 0, 0, 0],
+            [4, 0, 0, 0, 5, 0, 0],
+            [6, 0, 0, 0, 0, 0, 7],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 1, 0, 4, 0, 8],
+            [0, 9, 5, 0, 0, 0, 0],
+        ],
+    )
+    return algorithms.DsmMatrix.create(matrix)
+
+
+@pytest.fixture()
+def complex_matrix_done() -> algorithms.DsmMatrix:
+    """The complex matrix, sequenced.
+
+    Returns:
+        algorithms.DsmMatrix: _description_
+    """
+    matrix = structures.Matrix.cast(
+        ["f", "b", "d", "g", "c", "a", "e"],
+        [
+            [0, 0, 0, 8, 1, 0, 4],
+            [0, 0, 3, 0, 1, 0, 0],
+            [0, 0, 0, 7, 0, 6, 0],
+            [0, 9, 0, 0, 5, 0, 0],
+            [0, 0, 0, 0, 0, 4, 5],
+            [0, 0, 0, 0, 2, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ],
+    )
+    return algorithms.DsmMatrix.create(matrix)
+
+
+@pytest.fixture()
+def cluster_matrix() -> algorithms.DsmMatrix:
+    """The complex matrix, sequenced.
+
+    Returns:
+        algorithms.DsmMatrix: _description_
+    """
+    matrix = structures.Matrix.cast(
+        ["a", "b", "c", "d", "e", "f", "g"],
+        [
+            [0, 0, 0, 0, 0, 1, 0],
+            [1, 0, 1, 1, 0, 0, 1],
+            [0, 0, 0, 1, 0, 0, 1],
+            [0, 1, 1, 0, 1, 0, 1],
+            [1, 0, 0, 1, 0, 1, 0],
+            [1, 0, 0, 0, 1, 0, 0],
+            [0, 1, 1, 1, 0, 0, 0],
+        ],
+    )
+    return algorithms.DsmMatrix.create(matrix)
+
+
+def test_switch_elements(full_matrix: algorithms.DsmMatrix):  # noqa: WPS442
+    """Check that switching elements gives expected result.
+
+    Args:
+        full_matrix (algorithms.DsmMatrix): _description_
+    """
+    actual = full_matrix.switch_elements(0, 2)
+    assert actual.keys == ["c", "b", "a", "d"]
+    assert actual.data == [[11, 10, 9, 12], [7, 6, 5, 8], [3, 2, 1, 4], [15, 14, 13, 16]]
+
+
+def test_switch_elements_twice_is_null_operation(full_matrix: algorithms.DsmMatrix):  # noqa: WPS442
+    """Check that switching elements twice is reverting to original matrix.
+
+    Args:
+        full_matrix (algorithms.DsmMatrix): _description_
+    """
+    actual = full_matrix.switch_elements(0, 2)
+    actual = actual.switch_elements(0, 2)
+    assert actual.keys == full_matrix.keys
+    assert actual.data == full_matrix.data
+
+
+def test_element_to_front(full_matrix: algorithms.DsmMatrix):  # noqa: WPS442
+    """Check that element_to_front works as expected.
+
+    Args:
+        full_matrix (algorithms.DsmMatrix): the matrix to test with
+    """
+    actual = full_matrix.element_to_front(2)
+    assert actual.front == 1
+    assert actual.keys == ["c", "b", "a", "d"]
+
+    actual = actual.element_to_front(2)
+    assert actual.front == 2
+    assert actual.keys == ["c", "a", "b", "d"]
+
+
+def test_element_to_back(full_matrix: algorithms.DsmMatrix):  # noqa: WPS442
+    """Check that element_to_front works as expected.
+
+    Args:
+        full_matrix (algorithms.DsmMatrix): the matrix to test with
+    """
+    actual = full_matrix.element_to_back(1)
+    assert actual.back == actual.rank - 1
+    assert actual.keys == ["a", "d", "c", "b"]
+
+    actual = actual.element_to_back(1)
+    assert actual.back == actual.rank - 2
+    assert actual.keys == ["a", "c", "d", "b"]
+
+
+def test_has_inputs(sparse_matrix):
+    sparse_matrix.print()
+    assert not sparse_matrix.has_inputs(1)
+    assert sparse_matrix.has_inputs(2)
+
+
+def test_has_outputs(sparse_matrix):
+    sparse_matrix.print()
+    assert sparse_matrix.has_outputs(1)
+    assert not sparse_matrix.has_outputs(2)
+
+
+def test_sequence(complex_matrix, complex_matrix_done):
+    complex_matrix.print(zero=".")
+    result = complex_matrix.sequence()
+    result.print(zero=".")
+    complex_matrix_done.print(zero=".")
+    # assert False
+
+
+def test_reachability(cluster_matrix):
+    levels = cluster_matrix.get_levels()
+    print(levels)
+    levels = [x for xs in levels for x in xs]
+    print(levels)
+    cluster_matrix.print(zero=".")
+    cluster_matrix.levelize().print(zero=".")
+    assert False


### PR DESCRIPTION
The list of items is sorted so that dependencies flow downward, items should depend only on items below them. Of course, there
can be cycles, that are shown in the matrix below the diagonal.

Test for example with `pdm run dependenpy dependenpy -z .`, both the original matrix and the sorted one are printed. The modules also have their level printed out.

The algorithms I found work on the matrix, but we should adapt them to work with the underlying tree, so that even the other representations can take advantage, if relevant for those cases. The matrix can be further processed in order to detect clusters of modules that are interdependent.

This is a work in progress, just to get some feedback from you, please don't merge it (assuming it passes the CI checks :-) )