### PR TITLE
Add colorama as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
-dependencies = []
+dependencies = [
+    "colorama>=0.4.5"
+]
 
 [project.urls]
 Homepage = "https://pawamoy.github.io/dependenpy"


### PR DESCRIPTION
I'm not sure if this is the only missing dependency. Maybe PDM can't run the tests in an isolated environment, without the development dependencies?

Hmm, I just installed the version from pipy and it has colorama as dependency. Why doesn't "pdm build" include it locally? How are you building a release?